### PR TITLE
ci: add code coverage badge to README via GitHub Actions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,51 @@
+name: "Test Coverage"
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+    paths:
+      - "orchestrator/**"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "orchestrator/**"
+
+jobs:
+  test:
+    runs-on: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+
+      - name: Install dependencies
+        run: poetry install --with dev
+
+      - name: Run tests with coverage
+        run: |
+          poetry run coverage run -m pytest
+          poetry run coverage report
+          poetry run coverage json
+          export TOTAL=$(python -c "import json;print(json.load(open('coverage.json'))['totals']['percent_covered_display'])")
+          echo "total=$TOTAL" >> $GITHUB_ENV
+          echo "### Total coverage: ${TOTAL}%" >> $GITHUB_STEP_SUMMARY
+
+      - name: "Make badge"
+        uses: schneegans/dynamic-badges-action@v1.4.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: fb9b3bc6236ef7e8a1560403b5c58186
+          filename: covbadge.json
+          label: Coverage
+          message: ${{ env.total }}%
+          minColorRange: 50
+          maxColorRange: 90
+          valColorRange: ${{ env.total }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/__pycache__/*
 *.txt
 *.log
+.coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ log_cli = false
 log_cli_level = "DEBUG"
 log_cli_format = "%(asctime)s %(message)s (%(filename)s:%(lineno)s)"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+addopts = "--cov=orchestrator --cov-report html"
 
 [tool.ruff]
 target-version = "py310"


### PR DESCRIPTION
This pull request introduces a new workflow for test coverage and updates the test configuration to include coverage reporting. The key changes are:

### Workflow Enhancements:

* [`.github/workflows/coverage.yml`](diffhunk://#diff-a2115d277b5ca5a2f09a999e53440839cf332b94da177f3d1766334555b0f7c6R1-R51): Added a new GitHub Actions workflow named "Test Coverage" that runs on `workflow_dispatch`, `push`, and `pull_request` events for the `main` branch. It sets up Python, installs dependencies using Poetry, runs tests with coverage, and generates a coverage badge.

### Test Configuration Updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R38): Added `--cov=orchestrator --cov-report html` to the `addopts` section to enable coverage reporting during test runs.