### PR TITLE
ci: #39 update Python version to 3.12.3 and install GMT dependencies

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12.3"
+
+      - name: Install GMT and create symbolic link
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gmt libgmt-dev
+          sudo find /usr -name "libgmt.so.*" -exec sudo ln -sf {} $(dirname {})/libgmt.so \;
 
       - name: Install Poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,9 +23,8 @@ jobs:
         with:
           python-version: "3.12.3"
 
-      - name: Install GMT and create symbolic link
+      - name: gmt (#33) fix for libgmt symlink
         run: |
-          sudo apt-get update
           sudo apt-get install -y gmt libgmt-dev
           sudo find /usr -name "libgmt.so.*" -exec sudo ln -sf {} $(dirname {})/libgmt.so \;
 
@@ -52,6 +51,6 @@ jobs:
           filename: covbadge.json
           label: Coverage
           message: ${{ env.total }}%
-          minColorRange: 50
+          minColorRange: 40
           maxColorRange: 90
           valColorRange: ${{ env.total }}


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/coverage.yml` file to improve the Python setup and adjust the coverage badge settings. The most important changes include updating the Python version, adding a fix for the `libgmt` symlink, and modifying the coverage badge color range.

Updates to Python setup:

* Updated the Python version from `3.10` to `3.12.3` in the `Set up Python` step.
* Added a step to install `gmt` and `libgmt-dev`, and create a symlink for `libgmt.so`.

Adjustments to coverage badge settings:

* Changed the `minColorRange` for the coverage badge from 50 to 40.