### PR TITLE
chore(devcontainer): update Docker image to use development version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
     "name": "Orchestrator-TSDHN Dev",
 
-    "image": "ghcr.io/totallynotdavid/seismic-toolkit:main",
+    "image": "ghcr.io/totallynotdavid/seismic-toolkit-dev:main",
 
     "workspaceFolder": "/app",
     "workspaceMount": "source=${localWorkspaceFolder},target=/app,type=bind,consistency=cached",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,8 +22,6 @@
         }
     },
 
-    "postCreateCommand": "bash -c 'if ! command -v sudo &> /dev/null; then apt-get update && apt-get install -y sudo; fi && sudo apt-get update && sudo apt-get install -y git vim sudo nano htop git-lfs && sudo usermod -aG sudo appuser && echo \"appuser ALL=(ALL) NOPASSWD:ALL\" | sudo tee /etc/sudoers.d/appuser && pip install --user pylint black isort ipython pytest pytest-cov'",
-
     "postStartCommand": "echo 'Development environment ready!'",
 
     "customizations": {
@@ -33,11 +31,11 @@
                 "python.linting.pylintEnabled": true,
                 "python.linting.enabled": true,
                 "python.formatting.provider": "black",
-                "python.formatting.blackPath": "${workspaceFolder}/.local/bin/black",
+                "python.formatting.blackPath": "/opt/venv/bin/black",
                 "editor.formatOnSave": true,
                 "[python]": {
                     "editor.codeActionsOnSave": {
-                        "source.organizeImports": "explicit"
+                        "source.organizeImports": "always"
                     }
                 },
                 "terminal.integrated.defaultProfile.linux": "bash",

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # Folders
 /jobs/
+# devcontainer artifacts
+/.dotnet/
+/.cache/
+/.vscode-remote/
 
 # Files
 configuracion_*.json


### PR DESCRIPTION
This pull request updates the development container configuration to streamline the setup process and improve compatibility with the development environment. The most important changes include switching the container image to a development-specific version, simplifying the `postCreateCommand`, and adjusting Python-related settings.

### Development container updates:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L4-R4): Changed the container image from `seismic-toolkit:main` to `seismic-toolkit-dev:main` for better alignment with the development environment.
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L25-L26): Removed the `postCreateCommand` that installed various tools and dependencies, simplifying the container setup process.

### Python configuration adjustments:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L36-R38): Updated the `python.formatting.blackPath` to use `/opt/venv/bin/black` instead of a workspace-relative path for better compatibility with the container environment.
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L36-R38): Changed the `source.organizeImports` setting from `"explicit"` to `"always"` to ensure imports are consistently organized on save.